### PR TITLE
Fix time formats in json.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Consider downgrading Python requirement (at least to 3.10, but I dont know how low it can gowhere)
 
+## [0.8.3]
+
+### Fixed
+- +1 for next date now no longer causing json issues. Stopped working with the same OpenAI model after previous fix.
+
 ## [0.8.2]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ disallow_incomplete_defs = true
 
 [tool.poetry]
 name = "crewcal"
-version = "0.8.2"
+version = "0.8.3"
 description = "Convert an airline crew schedule pdf into iCalendar format."
 authors = ["Erik Oosterop <ni7h4txi@duck.com>"]
 license = "MIT"

--- a/src/crewcal/llm_prompts.py
+++ b/src/crewcal/llm_prompts.py
@@ -19,7 +19,7 @@ Each event contains the following items:
 - Destination airport name
 - Destination timezone
 - Arrival date. A '+1' means the next day.
-- Arrival time, the last occurrence of a time for each day. A '+1' means the next day.
+- Arrival time, the last occurrence of a time for each day. A '+1' means the next day. Only capture HH:mm format.
 - List of crew members
 - A list of all times found.
 - List of all airport codes.


### PR DESCRIPTION
<!-- Thank you for sending a PR and taking the time to improve crewcal -->

## Motivation

Correct handling of '+1' in end times.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/EJOOSTEROP/crewcal/blob/main/CONTRIBUTING.md)?

Yes/No

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)